### PR TITLE
Add maximum children validation limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ A rules engine for calculating BC Winter Supplement benefits.
 
 The goal of this assignment is to implement a business rules engine that determines eligibility and calculates the benefits a client is eligible to receive.
 
+## Assumptions & Constraints
+The engine implements the following validation rules and constraints:
+
+- Family composition has to be "single" or "couple" (case insensitive)
+- Number of children has to be a non-negative integer not exceeding 30
+  - I chose this upper limit to accommodate for most cases while making sure the system can't be misused
+  - I assume cases exceeding this limit would likely require manual review
+- Eligibility is determined by the `familyUnitInPayForDecember` status
+
 ## Installation
 
 Prerequisites:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -54,6 +54,18 @@ def test_validate_input_invalid_number_of_children():
     }
     assert validate_input(invalid_input) is None
 
+def test_validate_input_exceeds_maximum_children():
+    """
+    Test that validate returns None when number of children exceeds maximum limit
+    """
+    invalid_input = {
+        "id": "test123",
+        "numberOfChildren": 31,  # Exceeds maximum of 30 children
+        "familyComposition": "single",
+        "familyUnitInPayForDecember": True
+    }
+    assert validate_input(invalid_input) is None
+
 def test_validate_input_invalid_family_composition():
     """
     Test that validate returns None when family composition is not "single" or "couple"

--- a/winter_supplement_engine/rules.py
+++ b/winter_supplement_engine/rules.py
@@ -31,8 +31,9 @@ def validate_input(data: dict) -> Optional[WinterSupplementInput]:
             raise ValueError("id must be a string")
 
         # validate numberOfChildren
-        if not isinstance(data['numberOfChildren'], int) or data['numberOfChildren'] < 0:
-            raise ValueError("numberOfChildren must be a non-negative integer")
+        MAX_CHILDREN = 30  # reasonable maximum to protect against potential misuse
+        if not isinstance(data['numberOfChildren'], int) or data['numberOfChildren'] < 0 or data['numberOfChildren'] > MAX_CHILDREN:
+            raise ValueError(f"numberOfChildren must be a non-negative integer not exceeding {MAX_CHILDREN}")
 
         # validate familyComposition
         if data['familyComposition'].lower() not in ["single", "couple"]:


### PR DESCRIPTION
## Description:
This PR adds validation for the maximum number of children to prevent unrealistic inputs. 

- Adds a maximum limit of 30 children
- Updates validation logic and error messages
- Adds new test case for maximum children validation
- Documents assumptions in README

The limit of 30 children was chosen as it:
- Accommodates large families
- Aligns with realistic BC benefits scenarios
- Provides reasonable upper bound for validation