### PR TITLE
Fix on_disconnect callback in WinterSupplementEngine

### DIFF
--- a/winter_supplement_engine/engine.py
+++ b/winter_supplement_engine/engine.py
@@ -39,7 +39,7 @@ class WinterSupplementEngine:
         else:
             print(f"Failed to connect to MQTT broker with result code: {rc}")
 
-    def on_disconnect(self, client, userdata, rc):
+    def on_disconnect(self, client, userdata, disconnect_flags, rc, properties):
         if rc != 0:
             # print reason code for the disconnection
             print(f"Disconnected from MQTT broker: {rc}")


### PR DESCRIPTION
## Description
This PR fixes the `on_disconnect` method in the WinterSupplementEngine class to align with the expected callback signature from the paho-mqtt library.

## Changes
- Updated the `on_disconnect` method in WinterSupplementEngine to include these missing properties:
  - disconnect_flags
  - properties

## Why this fix?
I noticed that after leaving my engine running for a long time it eventually exited with the error:
```
An error occurred: WinterSupplementEngine.on_disconnect() takes 4 positional arguments but 6 were given
```

## Testing
I verified that the on_disconnect callback no longer causes the engine to crash. If this were a long-term project, I would also add unit tests to ensure proper handling of this callback in different scenarios.